### PR TITLE
Continue adding service tests

### DIFF
--- a/backend/src/main/java/com/inbarmi/typing_app_api/service/TypingSessionService.java
+++ b/backend/src/main/java/com/inbarmi/typing_app_api/service/TypingSessionService.java
@@ -22,11 +22,41 @@ public class TypingSessionService {
     }
 
     public int getSessionWpm(Long sessionId) {
-        return -1;
+        if (sessionId == null) {
+            throw new IllegalArgumentException("Invalid session Id");
+        }
+
+        TypingSession session = repository.getReferenceById(sessionId);
+        
+        return calcWpm(session.getTotalTyped(), session.getTimeInSeconds());
     }
 
     public int getSessionAccuracy(Long sessionId) {
-        return -1;
+        if (sessionId == null) {
+            throw new IllegalArgumentException("Invalid session Id");
+        }
+
+        TypingSession session = repository.getReferenceById(sessionId);
+        
+        return calcAccuracy(session.getTotalCorrect(), session.getTotalTyped());
     }
 
+    private int calcWpm(int totalTyped, int time) {
+        if (totalTyped == 0) {
+            return 0;
+        }
+
+        float words = totalTyped / 5.0f;
+        float minutes = time / 60.0f;
+
+        return Math.round(words / minutes); // assume average word length of 5 characters
+    }
+
+    private int calcAccuracy(int totalCorrect, int totalTyped) {
+        if (totalTyped == 0) {
+            return 0;
+        }
+
+        return Math.round((totalCorrect * 100.0f) / totalTyped);
+    }
 }

--- a/backend/src/test/java/com/inbarmi/typing_app_api/service/TypingSessionServiceTest.java
+++ b/backend/src/test/java/com/inbarmi/typing_app_api/service/TypingSessionServiceTest.java
@@ -103,12 +103,10 @@ class TypingSessionServiceTest {
 
         TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
 
-        when(repository.save(any()))
+        when(repository.getReferenceById(1L))
             .thenReturn(mockSession);
 
-        TypingSession result = service.saveTypingSession(totalTyped, totalCorrect, time);
-
-        int wpm = service.getSessionWpm(result.getId());
+        int wpm = service.getSessionWpm(1L);
         
         assertEquals(60, wpm);
     }
@@ -122,12 +120,10 @@ class TypingSessionServiceTest {
 
         TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
 
-        when(repository.save(any()))
+        when(repository.getReferenceById(1L))
             .thenReturn(mockSession);
 
-        TypingSession result = service.saveTypingSession(totalTyped, totalCorrect, time);
-
-        int wpm = service.getSessionWpm(result.getId());
+        int wpm = service.getSessionWpm(1L);
         
         assertEquals(56, wpm);
     }
@@ -140,12 +136,10 @@ class TypingSessionServiceTest {
 
         TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
 
-        when(repository.save(any()))
+        when(repository.getReferenceById(1L))
             .thenReturn(mockSession);
 
-        TypingSession result = service.saveTypingSession(totalTyped, totalCorrect, time);
-
-        int wpm = service.getSessionWpm(result.getId());
+        int wpm = service.getSessionWpm(1L);
         
         assertEquals(0, wpm);
     }
@@ -161,12 +155,10 @@ class TypingSessionServiceTest {
 
         TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
 
-        when(repository.save(any()))
+        when(repository.getReferenceById(1L))
             .thenReturn(mockSession);
 
-        TypingSession result = service.saveTypingSession(totalTyped, totalCorrect, time);
-
-        int accuracy = service.getSessionAccuracy(result.getId());
+        int accuracy = service.getSessionAccuracy(1L);
         
         assertEquals(83, accuracy);
     }
@@ -181,12 +173,10 @@ class TypingSessionServiceTest {
 
         TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
 
-        when(repository.save(any()))
+        when(repository.getReferenceById(1L))
             .thenReturn(mockSession);
 
-        TypingSession result = service.saveTypingSession(totalTyped, totalCorrect, time);
-
-        int accuracy = service.getSessionAccuracy(result.getId());
+        int accuracy = service.getSessionAccuracy(1L);
         
         assertEquals(92, accuracy);
     }
@@ -199,12 +189,10 @@ class TypingSessionServiceTest {
 
         TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
 
-        when(repository.save(any()))
+        when(repository.getReferenceById(1L))
             .thenReturn(mockSession);
 
-        TypingSession result = service.saveTypingSession(totalTyped, totalCorrect, time);
-
-        int accuracy = service.getSessionAccuracy(result.getId());
+        int accuracy = service.getSessionAccuracy(1L);
         
         assertEquals(0, accuracy);
     }


### PR DESCRIPTION
Closes #42
Closes #43 

Added the following test cases (not implemented yet):

- service returns accurate WPM given valid inputs (integer result)
- service returns rounded WPM given valid inputs
- service returns 0 WPM when nothing was typed without an error
- service returns accurate accuracy given valid inputs (integer result)
- service returns rounded accuracy given valid inputs
- service returns 0 accuracy when nothing was typed

Implemented TypingSessionService methods to get WPM and accuracy from session ID. All tests pass.