### PR TITLE
Add tests for controller, create REST controller, modify DTO to reque…

### DIFF
--- a/backend/src/main/java/com/inbarmi/typing_app_api/controller/TypingSessionController.java
+++ b/backend/src/main/java/com/inbarmi/typing_app_api/controller/TypingSessionController.java
@@ -1,0 +1,46 @@
+package com.inbarmi.typing_app_api.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RestController;
+import com.inbarmi.typing_app_api.service.TypingSessionService;
+import com.inbarmi.typing_app_api.dto.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/sessions")
+public class TypingSessionController {
+
+    private TypingSessionService service;
+
+    public TypingSessionController(TypingSessionService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/user/{userId}")
+    public ResponseEntity<TypingSessionResponse> createSession(@PathVariable String userId, @RequestBody TypingSessionRequest request) {
+        TypingSessionResponse response = service.saveTypingSession(userId, request);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<TypingSessionResponse> getSessionById(@PathVariable Long id) {
+        TypingSessionResponse response = service.getSessionById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<TypingSessionResponse>> getAllUserSessions(@PathVariable String userId) {
+        List<TypingSessionResponse> responses = service.getAllSessionsForUser(userId);
+        return ResponseEntity.ok(responses);
+    }
+}
+    
+    
+

--- a/backend/src/main/java/com/inbarmi/typing_app_api/dto/TypingSessionRequest.java
+++ b/backend/src/main/java/com/inbarmi/typing_app_api/dto/TypingSessionRequest.java
@@ -1,0 +1,19 @@
+package com.inbarmi.typing_app_api.dto;
+
+import java.time.Instant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class TypingSessionRequest {
+
+    private int totalTyped;
+    private int totalCorrect;
+    private int timeInSeconds;
+}

--- a/backend/src/main/java/com/inbarmi/typing_app_api/dto/TypingSessionResponse.java
+++ b/backend/src/main/java/com/inbarmi/typing_app_api/dto/TypingSessionResponse.java
@@ -1,0 +1,24 @@
+package com.inbarmi.typing_app_api.dto;
+
+import java.time.Instant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class TypingSessionResponse {
+    private Long id;
+    private String userId;
+    private int totalTyped;
+    private int totalCorrect;
+    private int timeInSeconds;
+    private int wpm;
+    private int accuracy;
+    private Instant createdAt;
+
+}

--- a/backend/src/main/java/com/inbarmi/typing_app_api/entity/TypingSession.java
+++ b/backend/src/main/java/com/inbarmi/typing_app_api/entity/TypingSession.java
@@ -20,6 +20,9 @@ public class TypingSession {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "user_id")
+    private String userId;
+
     @Column(name = "total_typed")
     private int totalTyped;
 
@@ -33,9 +36,10 @@ public class TypingSession {
     @CreationTimestamp
     private Instant createdAt;
 
-    public TypingSession(int totalTyped, int totalCorrect, int timeInSeconds) {
+    public TypingSession(int totalTyped, int totalCorrect, int timeInSeconds, String userId) {
         this.totalTyped = totalTyped;
         this.totalCorrect = totalCorrect;
         this.timeInSeconds = timeInSeconds;
+        this.userId = userId;
     }
 }

--- a/backend/src/main/java/com/inbarmi/typing_app_api/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/inbarmi/typing_app_api/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package com.inbarmi.typing_app_api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/inbarmi/typing_app_api/mapper/TypingSessionMapper.java
+++ b/backend/src/main/java/com/inbarmi/typing_app_api/mapper/TypingSessionMapper.java
@@ -1,0 +1,20 @@
+package com.inbarmi.typing_app_api.mapper;
+
+import com.inbarmi.typing_app_api.dto.TypingSessionResponse;
+import com.inbarmi.typing_app_api.entity.TypingSession;
+
+public class TypingSessionMapper {
+
+    public static TypingSessionResponse toResponse(TypingSession session, int wpm, int accuracy) {
+        return new TypingSessionResponse(
+            session.getId(),
+            session.getUserId(),
+            session.getTotalTyped(),
+            session.getTotalCorrect(),
+            session.getTimeInSeconds(),
+            wpm,
+            accuracy,
+            session.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/inbarmi/typing_app_api/repository/TypingSessionRepository.java
+++ b/backend/src/main/java/com/inbarmi/typing_app_api/repository/TypingSessionRepository.java
@@ -2,6 +2,10 @@ package com.inbarmi.typing_app_api.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.inbarmi.typing_app_api.entity.TypingSession;
+import java.util.List;
+
 
 public interface TypingSessionRepository extends JpaRepository<TypingSession, Long> {
+
+    List<TypingSession> findByUserId(String userId);
 }

--- a/backend/src/main/java/com/inbarmi/typing_app_api/service/TypingSessionService.java
+++ b/backend/src/main/java/com/inbarmi/typing_app_api/service/TypingSessionService.java
@@ -1,8 +1,13 @@
 package com.inbarmi.typing_app_api.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import com.inbarmi.typing_app_api.entity.TypingSession;
+import com.inbarmi.typing_app_api.mapper.TypingSessionMapper;
 import com.inbarmi.typing_app_api.repository.TypingSessionRepository;
+import com.inbarmi.typing_app_api.dto.*;
+import com.inbarmi.typing_app_api.exception.*;
 
 @Service
 public class TypingSessionService {
@@ -13,32 +18,34 @@ public class TypingSessionService {
         this.repository = repo;
     }
 
-    public TypingSession saveTypingSession(int totalTyped, int totalCorrect, int time) {
+    public TypingSessionResponse saveTypingSession(String userId, TypingSessionRequest request) {
+        int totalTyped = request.getTotalTyped();
+        int totalCorrect = request.getTotalCorrect();
+        int time = request.getTimeInSeconds();
+
         if (totalTyped < 0 || totalCorrect < 0 || time <= 0 || totalCorrect > totalTyped) {
             throw new IllegalArgumentException("Invalid input");
         }
-        TypingSession session = new TypingSession(totalTyped, totalCorrect, time);
-        return repository.save(session);
+        TypingSession session = new TypingSession(totalTyped, totalCorrect, time, userId);
+        TypingSession saved = repository.save(session);
+
+        return mapSession(saved);
     }
 
-    public int getSessionWpm(Long sessionId) {
-        if (sessionId == null) {
-            throw new IllegalArgumentException("Invalid session Id");
-        }
+    public TypingSessionResponse getSessionById(Long sessionId) {
+        TypingSession session = repository.findById(sessionId)
+            .orElseThrow(() ->
+                new ResourceNotFoundException("Session does not exist with id: " + sessionId));
 
-        TypingSession session = repository.getReferenceById(sessionId);
-        
-        return calcWpm(session.getTotalTyped(), session.getTimeInSeconds());
+        return mapSession(session);
     }
 
-    public int getSessionAccuracy(Long sessionId) {
-        if (sessionId == null) {
-            throw new IllegalArgumentException("Invalid session Id");
-        }
+    public List<TypingSessionResponse> getAllSessionsForUser(String userId) {
+        List<TypingSession> sessions = repository.findByUserId(userId);
 
-        TypingSession session = repository.getReferenceById(sessionId);
-        
-        return calcAccuracy(session.getTotalCorrect(), session.getTotalTyped());
+        return sessions.stream()
+            .map(this::mapSession)
+            .toList();
     }
 
     private int calcWpm(int totalTyped, int time) {
@@ -58,5 +65,12 @@ public class TypingSessionService {
         }
 
         return Math.round((totalCorrect * 100.0f) / totalTyped);
+    }
+
+    private TypingSessionResponse mapSession(TypingSession session) {
+        int wpm = calcWpm(session.getTotalTyped(), session.getTimeInSeconds());
+        int accuracy = calcAccuracy(session.getTotalCorrect(), session.getTotalTyped());
+
+        return TypingSessionMapper.toResponse(session, wpm, accuracy);
     }
 }

--- a/backend/src/test/java/com/inbarmi/typing_app_api/controller/TypingSessionControllerTest.java
+++ b/backend/src/test/java/com/inbarmi/typing_app_api/controller/TypingSessionControllerTest.java
@@ -1,0 +1,111 @@
+package com.inbarmi.typing_app_api.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import static org.mockito.Mockito.*;
+import com.inbarmi.typing_app_api.service.TypingSessionService;
+import com.inbarmi.typing_app_api.dto.*;
+import com.inbarmi.typing_app_api.exception.ResourceNotFoundException;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class TypingSessionControllerTest {
+
+    @Mock
+    private TypingSessionService service;
+
+    @InjectMocks
+    private TypingSessionController controller;
+
+    // POST /sessions/user/{userId}
+    @Test
+    void createSession_validRequest_returnsCreatedResponse() {
+        TypingSessionRequest request = new TypingSessionRequest(300, 270, 60);
+
+        TypingSessionResponse response = new TypingSessionResponse(1L, "test-user", 300, 270, 60, 60, 90, null);
+
+        when(service.saveTypingSession("test-user", request))
+            .thenReturn(response);
+        
+        ResponseEntity<TypingSessionResponse> result = controller.createSession("test-user", request);
+
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+        assertEquals(response, result.getBody());
+
+        verify(service).saveTypingSession("test-user", request);
+    }
+
+    @Test
+    void createSession_invalidRequest_throwsException() {
+        TypingSessionRequest request = new TypingSessionRequest(-100, 50, 60);
+
+        when(service.saveTypingSession("test-user", request))
+            .thenThrow(new IllegalArgumentException());
+
+        assertThrows(IllegalArgumentException.class, () -> controller.createSession("test-user", request));
+    }
+
+    // GET /sessions/{id}
+    @Test
+    void getSessionById_existingSession_returnsSession() {
+        
+        TypingSessionResponse response = new TypingSessionResponse(1L, "test-user", 300, 270, 60, 60, 90, null);
+
+        when(service.getSessionById(1L))
+            .thenReturn(response);
+        
+        ResponseEntity<TypingSessionResponse> result = controller.getSessionById(1L);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(response, result.getBody());
+
+        verify(service).getSessionById(1L);
+    }
+
+    @Test
+    void getSessionById_nonExistentSession_throwsNotFound() {
+
+        when(service.getSessionById(1L))
+        .thenThrow(new ResourceNotFoundException("not found"));
+
+        assertThrows(ResourceNotFoundException.class, () ->
+            controller.getSessionById(1L)
+    );
+    }
+
+    // GET /sessions/user/{id}
+    @Test
+    void getAllUserSessions_returnsList() {
+        List<TypingSessionResponse> sessions = List.of(
+            new TypingSessionResponse(1L, "test-user", 300, 270, 60, 60, 90, null),
+            new TypingSessionResponse(2L, "test-user", 250, 200, 60, 50, 80, null)
+        );
+
+        when(service.getAllSessionsForUser("test-user"))
+            .thenReturn(sessions);
+
+        ResponseEntity<List<TypingSessionResponse>> result = controller.getAllUserSessions("test-user");
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(2, result.getBody().size());
+
+        verify(service).getAllSessionsForUser("test-user");
+    }
+
+    @Test
+    void getAllUserSessions_noSessions_returnsEmptyList() {
+        when(service.getAllSessionsForUser("test-user"))
+            .thenReturn(List.of());
+
+        ResponseEntity<List<TypingSessionResponse>> result = controller.getAllUserSessions("test-user");
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertTrue(result.getBody().isEmpty());
+    }
+}

--- a/backend/src/test/java/com/inbarmi/typing_app_api/service/TypingSessionServiceTest.java
+++ b/backend/src/test/java/com/inbarmi/typing_app_api/service/TypingSessionServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import com.inbarmi.typing_app_api.entity.TypingSession;
 import com.inbarmi.typing_app_api.repository.TypingSessionRepository;
+import com.inbarmi.typing_app_api.dto.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -22,178 +23,184 @@ class TypingSessionServiceTest {
 
     @Test
     void shouldRejectNegativeTotalTyped() {
-        int totalTyped = -100;
-        int totalCorrect = 50;
-        int time = 60;
+        TypingSessionRequest dto = new TypingSessionRequest(-100, 50, 60);
 
         assertThrows(IllegalArgumentException.class, () ->
-            service.saveTypingSession(totalTyped, totalCorrect, time)
+            service.saveTypingSession("test-user", dto)
         );
     }
 
     @Test
     void shouldRejectNegativeTotalCorrect() {
-        int totalTyped = 100;
-        int totalCorrect = -50;
-        int time = 60;
+        TypingSessionRequest dto = new TypingSessionRequest(100, -50, 60);
 
         assertThrows(IllegalArgumentException.class, () ->
-            service.saveTypingSession(totalTyped, totalCorrect, time)
+            service.saveTypingSession("test-user", dto)
         );
     }
 
     @Test
     void shouldRejectZeroTime() {
-        int totalTyped = 150;
-        int totalCorrect = 125;
-        int time = 0;
+        TypingSessionRequest dto = new TypingSessionRequest(150, 125, 0);
 
         assertThrows(IllegalArgumentException.class, () ->
-            service.saveTypingSession(totalTyped, totalCorrect, time)
+            service.saveTypingSession("test-user", dto)
         );
     }
 
     @Test
     void shouldRejectNegativeTime() {
-        int totalTyped = 150;
-        int totalCorrect = 125;
-        int time = -60;
+        TypingSessionRequest dto = new TypingSessionRequest(150, 125, -60);
 
         assertThrows(IllegalArgumentException.class, () ->
-            service.saveTypingSession(totalTyped, totalCorrect, time)
+            service.saveTypingSession("test-user", dto)
         );
     }
 
     @Test
     void shouldRejectTotalCorrectExceedsTotalTyped() {
-        int totalTyped = 100;
-        int totalCorrect = 150;
-        int time = 60;
+        TypingSessionRequest dto = new TypingSessionRequest(100, 150, 60);
 
         assertThrows(IllegalArgumentException.class, () ->
-            service.saveTypingSession(totalTyped, totalCorrect, time)
+            service.saveTypingSession("test-user", dto)
         );
     }
 
     @Test
-    void saveTypingSessionShouldReturnSessionForValidInputs() {
-        int totalTyped = 300;
-        int totalCorrect = 270;
-        int time = 60;
+    void saveTypingSessionShouldReturnDtoWithStats() {
+        TypingSessionRequest request = new TypingSessionRequest(300, 270, 60);
 
-        TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
+        TypingSession mockSession = new TypingSession(300, 270, 60, "test-user");
 
         when(repository.save(Mockito.any()))
             .thenReturn(mockSession);
         
-        TypingSession result = service.saveTypingSession(totalTyped, totalCorrect, time);
+        TypingSessionResponse result = service.saveTypingSession("test-user", request);
 
-        assertEquals(totalTyped, result.getTotalTyped());
-        assertEquals(totalCorrect, result.getTotalCorrect());
-        assertEquals(time, result.getTimeInSeconds());
+        assertEquals(300, result.getTotalTyped());
+        assertEquals(270, result.getTotalCorrect());
+        assertEquals(60, result.getTimeInSeconds());
+        assertEquals("test-user", result.getUserId());
+        assertEquals(60, result.getWpm());
+        assertEquals(90, result.getAccuracy());
     }
 
     @Test
-    void validInputReturnsCorrectWpm() {
-        // (totalTyped / 5) / (time / 60)
-        // expected 60 wpm
-        int totalTyped = 300;
-        int time = 60;
-        int totalCorrect = 250;
+    void saveTypingSessionWithNothingTypedReturnsZeroStats() {
+        TypingSessionRequest request = new TypingSessionRequest(0, 0, 60);
 
-        TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
+        TypingSession mockSession = new TypingSession(0, 0, 60, "test-user");
 
-        when(repository.getReferenceById(1L))
+        when(repository.save(Mockito.any()))
             .thenReturn(mockSession);
-
-        int wpm = service.getSessionWpm(1L);
         
-        assertEquals(60, wpm);
-    }
-    @Test
-    void validInputReturnsRoundedWpm() {
-        // (totalTyped / 5) / (time / 60)
-        // expected 56 wpm (round 55.6)
-        int totalTyped = 278;
-        int time = 60;
-        int totalCorrect = 250;
+        TypingSessionResponse result = service.saveTypingSession("test-user", request);
 
-        TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
-
-        when(repository.getReferenceById(1L))
-            .thenReturn(mockSession);
-
-        int wpm = service.getSessionWpm(1L);
-        
-        assertEquals(56, wpm);
+        assertEquals(0, result.getWpm());
+        assertEquals(0, result.getAccuracy());
     }
 
-    @Test
-    void nothingTypedShouldReturnZeroWpm() {
-        int totalTyped = 0;
-        int totalCorrect = 0;
-        int time = 60;
+    // @Test
+    // void validInputReturnsCorrectWpm() {
+    //     // (totalTyped / 5) / (time / 60)
+    //     // expected 60 wpm
+    //     int totalTyped = 300;
+    //     int time = 60;
+    //     int totalCorrect = 250;
 
-        TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
+    //     TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time, "test-user");
 
-        when(repository.getReferenceById(1L))
-            .thenReturn(mockSession);
+    //     when(repository.getReferenceById(1L))
+    //         .thenReturn(mockSession);
 
-        int wpm = service.getSessionWpm(1L);
+    //     int wpm = service.getSessionWpm(1L);
         
-        assertEquals(0, wpm);
-    }
+    //     assertEquals(60, wpm);
+    // }
+    // @Test
+    // void validInputReturnsRoundedWpm() {
+    //     // (totalTyped / 5) / (time / 60)
+    //     // expected 56 wpm (round 55.6)
+    //     int totalTyped = 278;
+    //     int time = 60;
+    //     int totalCorrect = 250;
 
+    //     TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time, "test-user");
 
-    @Test
-    void validInputReturnsCorrectAccuracy() {
-        // (totalCorrect / totalTyped) * 100
-        // expected 83%
-        int totalTyped = 300;
-        int time = 60;
-        int totalCorrect = 250;
+    //     when(repository.getReferenceById(1L))
+    //         .thenReturn(mockSession);
 
-        TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
-
-        when(repository.getReferenceById(1L))
-            .thenReturn(mockSession);
-
-        int accuracy = service.getSessionAccuracy(1L);
+    //     int wpm = service.getSessionWpm(1L);
         
-        assertEquals(83, accuracy);
-    }
+    //     assertEquals(56, wpm);
+    // }
 
-    @Test
-    void validInputReturnsRoundedAccuracy() {
-        // (totalCorrect / totalTyped) * 100
-        // expected 92% (round 91.6)
-        int totalTyped = 300;
-        int time = 60;
-        int totalCorrect = 275;
+    // @Test
+    // void nothingTypedShouldReturnZeroWpm() {
+    //     int totalTyped = 0;
+    //     int totalCorrect = 0;
+    //     int time = 60;
 
-        TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
+    //     TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time, "test-user");
 
-        when(repository.getReferenceById(1L))
-            .thenReturn(mockSession);
+    //     when(repository.getReferenceById(1L))
+    //         .thenReturn(mockSession);
 
-        int accuracy = service.getSessionAccuracy(1L);
+    //     int wpm = service.getSessionWpm(1L);
         
-        assertEquals(92, accuracy);
-    }
+    //     assertEquals(0, wpm);
+    // }
 
-    @Test
-    void nothingTypedShouldReturnZeroAccuracy() {
-        int totalTyped = 0;
-        int totalCorrect = 0;
-        int time = 60;
 
-        TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time);
+    // @Test
+    // void validInputReturnsCorrectAccuracy() {
+    //     // (totalCorrect / totalTyped) * 100
+    //     // expected 83%
+    //     int totalTyped = 300;
+    //     int time = 60;
+    //     int totalCorrect = 250;
 
-        when(repository.getReferenceById(1L))
-            .thenReturn(mockSession);
+    //     TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time, "test-user");
 
-        int accuracy = service.getSessionAccuracy(1L);
+    //     when(repository.getReferenceById(1L))
+    //         .thenReturn(mockSession);
+
+    //     int accuracy = service.getSessionAccuracy(1L);
         
-        assertEquals(0, accuracy);
-    }
+    //     assertEquals(83, accuracy);
+    // }
+
+    // @Test
+    // void validInputReturnsRoundedAccuracy() {
+    //     // (totalCorrect / totalTyped) * 100
+    //     // expected 92% (round 91.6)
+    //     int totalTyped = 300;
+    //     int time = 60;
+    //     int totalCorrect = 275;
+
+    //     TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time, "test-user");
+
+    //     when(repository.getReferenceById(1L))
+    //         .thenReturn(mockSession);
+
+    //     int accuracy = service.getSessionAccuracy(1L);
+        
+    //     assertEquals(92, accuracy);
+    // }
+
+    // @Test
+    // void nothingTypedShouldReturnZeroAccuracy() {
+    //     int totalTyped = 0;
+    //     int totalCorrect = 0;
+    //     int time = 60;
+
+    //     TypingSession mockSession = new TypingSession(totalTyped, totalCorrect, time, "test-user");
+
+    //     when(repository.getReferenceById(1L))
+    //         .thenReturn(mockSession);
+
+    //     int accuracy = service.getSessionAccuracy(1L);
+        
+    //     assertEquals(0, accuracy);
+    // }
 }


### PR DESCRIPTION
Closes #45, #46 

Adds REST endpoints for managing typing sessions:
- `POST /sessions/user/{userId}` – create a new typing session
- `GET /sessions/{id}` – retrieve a session by ID
- `GET /sessions/user/{userId}` – retrieve all sessions for a user

Routes are tested, but may need to add more tests. Updated to use response and request DTOs.